### PR TITLE
Change of parameters of 3d project causes a division by zero error 

### DIFF
--- a/M2DO_FEA/src/sensitivity.cpp
+++ b/M2DO_FEA/src/sensitivity.cpp
@@ -912,7 +912,12 @@ double SensitivityAnalysis :: SolveLeastSquares(vector<LeastSquares> least_squar
       std::vector<double> AtAp(matrix_size,0.0);
       AtAp = mat_vec_mult(AtA,p_inhouse); // AtA*p
 
-      alpha = vec_vec_mult(r_inhouse,r_inhouse)/ vec_vec_mult(p_inhouse, AtAp) ;
+	  auto divisor = vec_vec_mult(p_inhouse, AtAp);
+	  if (divisor == 0)
+	  {
+		  cout << "Division by zero error in SolveLeastSquares in 'sensitivity.cpp' at line: " << __LINE__ + 2 << endl;
+	  }
+      alpha = vec_vec_mult(r_inhouse,r_inhouse)/ divisor ; //DIVISOR IS SOMETIMES 0
 
       for(int i = 0; i < matrix_size; i++) X[i] += alpha*p_inhouse[i];
 

--- a/projects/3d/comp_min.cpp
+++ b/projects/3d/comp_min.cpp
@@ -25,7 +25,7 @@ int main () {
 		FEA & level set mesh parameters:
 	*/
 
-    const unsigned int nelx = 40, nely = 20, nelz = 20;
+    const unsigned int nelx = 30, nely = 30, nelz = 15;
 
     /*
         Create an FEA mesh object.
@@ -59,7 +59,7 @@ int main () {
 		Add material properties:
 	*/
 
-    fea_mesh.solid_materials.push_back (FEA::SolidMaterial (spacedim, 1.0, 0.3, 1.0)) ;
+    fea_mesh.solid_materials.push_back (FEA::SolidMaterial (spacedim, 20.0, 0.3, 10.0)) ;
 
     /*
         Next we specify that we will undertake a stationary study, which takes the form [K]{u} = {f}.
@@ -82,7 +82,7 @@ int main () {
         Apply load.
     */
 
-    vector<int> load_node = fea_mesh.GetNodesByCoordinates ({nelx, 0.0*nely,0.0*nelz}, {1.0e-12, 1.0e9, 1.e-12}) ;
+    vector<int> load_node = fea_mesh.GetNodesByCoordinates ({nelx, 0.0*nely,1.0*nelz}, {1.0e-12, 1.0e9, 1.5}) ;
     vector<int> load_dof  = fea_mesh.dof (load_node) ;
 
 
@@ -235,7 +235,7 @@ int main () {
 					SensData.vsens[i] = -1 ;
 
 					// assign large values to sensitivities along the boundary where load is applied
-					if(boundary_point[0] >= nelx - 2 && boundary_point[2] <= 2 ) SensData.bsens[i] = 1.0e5 ;
+					if (boundary_point[0] >= nelx - 2 && boundary_point[2] >= nelz - 2) SensData.bsens[i] = 1.0e5;
 				}
 
 				sens.boundary_sensitivities.clear();

--- a/projects/3d/comp_min.cpp
+++ b/projects/3d/comp_min.cpp
@@ -137,7 +137,7 @@ int main () {
 		// Create a sensitivity object
 		SensitivityData SensData;
 
-		double MaxVol = 30.0; // in percentage
+		double MaxVol = 10.0; // in percentage
 	  SensData.MaxVol = MaxVol;
 
 	  std::vector<double> UB(2,0);


### PR DESCRIPTION
When running the 3d example with the following parameters, I got a division by 0 error in M2DO_FEA/sensitivity.cpp. The following change to sensitivity.cpp will print an error message when it happens. The optimization continues nevertheless, but seems like an odd thing to happen. 
